### PR TITLE
Add unified API support and fix the build mechanism appropriately.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "arrayfire"
 description   = "ArrayFire is a high performance software library for parallel computing with an easy-to-use API. Its array based function set makes parallel programming simple. ArrayFire's multiple backends (CUDA, OpenCL and native CPU) make it platform independent and highly portable. A few lines of code in ArrayFire can replace dozens of lines of parallel computing code, saving you valuable time and lowering development costs. This crate provides Rust bindings for ArrayFire library."
-version       = "3.0.0"
+version       = "3.1.3"
 documentation = "http://arrayfire.github.io/arrayfire-rust/arrayfire/index.html"
 homepage      = "https://github.com/arrayfire/arrayfire"
 repository    = "https://github.com/arrayfire/arrayfire-rust"
@@ -26,6 +26,10 @@ path = "src/lib.rs"
 [[example]]
 name = "helloworld"
 path = "examples/helloworld.rs"
+
+[[example]]
+name = "unified"
+path = "examples/unified.rs"
 
 [[example]]
 name = "pi"

--- a/README.md
+++ b/README.md
@@ -112,5 +112,4 @@ You might see something along the lines of :
 dyld: Library not loaded: @rpath/libafopencl.3.dylib
 ```
 
-This is related to this [Rust issue](https://github.com/rust-lang/rust/issues/25185)
-A workaround for now is to add the location of libaf*.dylib to your LD_LIBRARY_PATH.
+You need to add the location of libaf.{dylib, so, dll} to your LD_LIBRARY_PATH.

--- a/build.conf
+++ b/build.conf
@@ -1,15 +1,10 @@
 {
-    "use_backend": "cpu",
-
     "use_lib": false,
     "lib_dir": "/usr/local/lib",
     "inc_dir": "/usr/local/include",
 
     "build_type": "Release",
     "build_threads": "4",
-    "build_cuda": "OFF",
-    "build_opencl": "ON",
-    "build_cpu": "ON",
     "build_examples": "OFF",
     "build_test": "OFF",
     "build_graphics": "ON",
@@ -31,5 +26,5 @@
 
     "cuda_sdk": "/usr/local/cuda",
     "opencl_sdk": "/usr",
-    "sdk_lib_dir": "lib"
+    "sdk_lib_dir": "lib64"
 }

--- a/examples/unified.rs
+++ b/examples/unified.rs
@@ -21,22 +21,33 @@ fn test_backend(){
 
 #[allow(unused_must_use)]
 fn main() {
-  println!("There are {} available backends", get_backend_count().unwrap());
-  let err = set_backend(AfBackend::AF_BACKEND_CPU);
-  match err {
-    Ok(_)  => test_backend(),
-    Err(e) => println!("CPU backend not available: {}", e),
-  };
+  println!("There are {:?} available backends", get_backend_count().unwrap());
+  let available = get_available_backends().unwrap();
 
-  let err = set_backend(AfBackend::AF_BACKEND_CUDA);
-  match err {
-    Ok(_)  => test_backend(),
-    Err(e) => println!("CUDA backend not available: {}", e),
-  };
+  if available.contains(&AfBackend::AF_BACKEND_CPU){
+    println!("Evaluating CPU Backend...");
+    let err = set_backend(AfBackend::AF_BACKEND_CPU);
+      match err {
+        Ok(_)  => test_backend(),
+        Err(e) => println!("CPU backend error: {}", e),
+    };
+  }
 
-  let err = set_backend(AfBackend::AF_BACKEND_OPENCL);
-  match err {
-    Ok(_)  => test_backend(),
-    Err(e) => println!("OpenCL backend not available: {}", e),
-  };
+  if available.contains(&AfBackend::AF_BACKEND_CUDA){
+    println!("Evaluating CUDA Backend...");
+    let err = set_backend(AfBackend::AF_BACKEND_CUDA);
+      match err {
+        Ok(_)  => test_backend(),
+        Err(e) => println!("CUDA backend error: {}", e),
+    };
+  }
+
+  if available.contains(&AfBackend::AF_BACKEND_OPENCL){
+    println!("Evaluating OpenCL Backend...");
+    let err = set_backend(AfBackend::AF_BACKEND_OPENCL);
+      match err {
+        Ok(_)  => test_backend(),
+        Err(e) => println!("OpenCL backend error: {}", e),
+    };
+  }
 }

--- a/examples/unified.rs
+++ b/examples/unified.rs
@@ -26,6 +26,7 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_CPU){
     println!("Evaluating CPU Backend...");
+    println!("There are {} CPU compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_CPU);
       match err {
         Ok(_)  => test_backend(),
@@ -35,6 +36,7 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_CUDA){
     println!("Evaluating CUDA Backend...");
+    println!("There are {} CUDA compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_CUDA);
       match err {
         Ok(_)  => test_backend(),
@@ -44,6 +46,7 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_OPENCL){
     println!("Evaluating OpenCL Backend...");
+    println!("There are {} OpenCL compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_OPENCL);
       match err {
         Ok(_)  => test_backend(),

--- a/examples/unified.rs
+++ b/examples/unified.rs
@@ -10,7 +10,7 @@ fn test_backend(){
   let num_cols: u64 = 10;
   let dims = Dim4::new(&[num_rows, num_cols, 1, 1]);
 
-  println!("Create a 5-by-3 matrix of random floats on the compute device");
+  println!("Create a 10-by-10 matrix of random floats on the compute device");
   let a = match randu(dims, Aftype::F32) {
     Ok(value) => value,
     Err(error) => panic!("{}", error),

--- a/examples/unified.rs
+++ b/examples/unified.rs
@@ -26,8 +26,8 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_CPU){
     println!("Evaluating CPU Backend...");
-    println!("There are {} CPU compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_CPU);
+    println!("There are {} CPU compute devices", device_count().unwrap());
       match err {
         Ok(_)  => test_backend(),
         Err(e) => println!("CPU backend error: {}", e),
@@ -36,8 +36,8 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_CUDA){
     println!("Evaluating CUDA Backend...");
-    println!("There are {} CUDA compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_CUDA);
+    println!("There are {} CUDA compute devices", device_count().unwrap());
       match err {
         Ok(_)  => test_backend(),
         Err(e) => println!("CUDA backend error: {}", e),
@@ -46,8 +46,8 @@ fn main() {
 
   if available.contains(&AfBackend::AF_BACKEND_OPENCL){
     println!("Evaluating OpenCL Backend...");
-    println!("There are {} OpenCL compute devices", device_count().unwrap());
     let err = set_backend(AfBackend::AF_BACKEND_OPENCL);
+    println!("There are {} OpenCL compute devices", device_count().unwrap());
       match err {
         Ok(_)  => test_backend(),
         Err(e) => println!("OpenCL backend error: {}", e),

--- a/examples/unified.rs
+++ b/examples/unified.rs
@@ -1,0 +1,42 @@
+extern crate arrayfire as af;
+
+use af::*;
+
+#[allow(unused_must_use)]
+fn test_backend(){
+  info();
+
+  let num_rows: u64 = 10;
+  let num_cols: u64 = 10;
+  let dims = Dim4::new(&[num_rows, num_cols, 1, 1]);
+
+  println!("Create a 5-by-3 matrix of random floats on the compute device");
+  let a = match randu(dims, Aftype::F32) {
+    Ok(value) => value,
+    Err(error) => panic!("{}", error),
+  };
+  print(&a);
+}
+
+
+#[allow(unused_must_use)]
+fn main() {
+  println!("There are {} available backends", get_backend_count().unwrap());
+  let err = set_backend(AfBackend::AF_BACKEND_CPU);
+  match err {
+    Ok(_)  => test_backend(),
+    Err(e) => println!("CPU backend not available: {}", e),
+  };
+
+  let err = set_backend(AfBackend::AF_BACKEND_CUDA);
+  match err {
+    Ok(_)  => test_backend(),
+    Err(e) => println!("CUDA backend not available: {}", e),
+  };
+
+  let err = set_backend(AfBackend::AF_BACKEND_OPENCL);
+  match err {
+    Ok(_)  => test_backend(),
+    Err(e) => println!("OpenCL backend not available: {}", e),
+  };
+}

--- a/src/defines.rs
+++ b/src/defines.rs
@@ -47,6 +47,19 @@ pub enum AfError {
     ERR_UNKNOWN        = 999
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum AfBackend {
+    /// Default backend order: OpenCL -> CUDA -> CPU
+    AF_BACKEND_DEFAULT = 0,
+    /// CPU a.k.a sequential algorithms
+    AF_BACKEND_CPU     = 1,
+    /// CUDA Compute Backend
+    AF_BACKEND_CUDA    = 2,
+    /// OpenCL Compute Backend
+    AF_BACKEND_OPENCL  = 3
+}
+
 impl Display for AfError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         write!(f, "{}", self.description())

--- a/src/defines.rs
+++ b/src/defines.rs
@@ -48,7 +48,7 @@ pub enum AfError {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AfBackend {
     /// Default backend order: OpenCL -> CUDA -> CPU
     AF_BACKEND_DEFAULT = 0,
@@ -58,6 +58,18 @@ pub enum AfBackend {
     AF_BACKEND_CUDA    = 2,
     /// OpenCL Compute Backend
     AF_BACKEND_OPENCL  = 3
+}
+
+impl Display for AfBackend {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        let text = match *self {
+            AfBackend::AF_BACKEND_OPENCL  => "OpenCL",
+            AfBackend::AF_BACKEND_CUDA    => "Cuda",
+            AfBackend::AF_BACKEND_CPU     => "CPU",
+            AfBackend::AF_BACKEND_DEFAULT => "Default",
+        };
+        write!(f, "{}", text)
+    }
 }
 
 impl Display for AfError {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,21 +1,18 @@
 extern crate libc;
 
-use defines::AfError;
-use self::libc::c_int;
+use defines::{AfError, AfBackend};
+use self::libc::{c_int, c_uint, uint8_t};
+
 
 extern {
     fn af_get_version(major: *mut c_int, minor: *mut c_int, patch: *mut c_int) -> c_int;
-
     fn af_info() -> c_int;
-
     fn af_get_device_count(nDevices: *mut c_int) -> c_int;
-
     fn af_get_dbl_support(available: *mut c_int, device: c_int) -> c_int;
-
     fn af_set_device(device: c_int) -> c_int;
-
+    fn af_set_backend(bknd: uint8_t) -> c_int;
+    fn af_get_backend_count(num_backends: *mut c_uint) -> c_int;
     fn af_get_device(device: *mut c_int) -> c_int;
-
     fn af_sync(device: c_int) -> c_int;
 }
 
@@ -131,6 +128,34 @@ pub fn sync(device: i32) -> Result<(), AfError> {
         let err_val = af_sync(device as c_int);
         match err_val {
             0 => Ok(()),
+            _ => Err(AfError::from(err_val)),
+        }
+    }
+}
+
+/// Toggle backends between cuda, opencl or cpu
+///
+/// # Parameters
+///
+/// - `backend` to which to switch to
+pub fn set_backend(backend: AfBackend) -> Result<(), AfError> {
+    unsafe {
+        let err_val = af_set_backend(backend as uint8_t);
+        match err_val {
+            0 => Ok(()),
+            _ => Err(AfError::from(err_val)),
+        }
+    }
+}
+
+/// Get the available backend count
+#[allow(unused_mut)]
+pub fn get_backend_count() -> Result<u32, AfError> {
+    unsafe {
+        let mut temp: u32 = 0;
+        let err_val = af_get_backend_count(&mut temp as *mut c_uint);
+        match err_val {
+            0 => Ok(temp),
             _ => Err(AfError::from(err_val)),
         }
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -12,6 +12,7 @@ extern {
     fn af_set_device(device: c_int) -> c_int;
     fn af_set_backend(bknd: uint8_t) -> c_int;
     fn af_get_backend_count(num_backends: *mut c_uint) -> c_int;
+    fn af_get_available_backends(backends: *mut c_int) -> c_int;
     fn af_get_device(device: *mut c_int) -> c_int;
     fn af_sync(device: c_int) -> c_int;
 }
@@ -156,6 +157,26 @@ pub fn get_backend_count() -> Result<u32, AfError> {
         let err_val = af_get_backend_count(&mut temp as *mut c_uint);
         match err_val {
             0 => Ok(temp),
+            _ => Err(AfError::from(err_val)),
+        }
+    }
+}
+
+
+/// Get the available backends
+#[allow(unused_mut)]
+pub fn get_available_backends() -> Result<Vec<AfBackend>, AfError> {
+    unsafe {
+        let mut temp: i32 = 0;
+        let err_val = af_get_available_backends(&mut temp as *mut c_int);
+        match err_val {
+            0 => {
+                let mut b = Vec::new();
+                if temp & 0b0100 == 0b0100 { b.push(AfBackend::AF_BACKEND_OPENCL); }
+                if temp & 0b0010 == 0b0010 { b.push(AfBackend::AF_BACKEND_CUDA); }
+                if temp & 0b0001 == 0b0001 { b.push(AfBackend::AF_BACKEND_CPU); }
+                Ok(b)
+            },
             _ => Err(AfError::from(err_val)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,10 @@ pub use data::{reorder, shift, moddims, flat, flip};
 pub use data::{select, selectl, selectr, replace, replace_scalar};
 mod data;
 
-pub use device::{get_version, info, device_count, is_double_available, set_device, get_device, sync};
+pub use device::{get_version, info, device_count, is_double_available, set_device, get_device, sync, get_backend_count, set_backend};
 mod device;
 
-pub use defines::{Aftype, AfError, ColorMap, YCCStd};
+pub use defines::{Aftype, AfError, AfBackend, ColorMap, YCCStd};
 pub use defines::{InterpType, BorderType, MatchType, NormType};
 pub use defines::{Connectivity, ConvMode, ConvDomain, ColorSpace, MatProp};
 mod defines;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,9 @@ pub use data::{reorder, shift, moddims, flat, flip};
 pub use data::{select, selectl, selectr, replace, replace_scalar};
 mod data;
 
-pub use device::{get_version, info, device_count, is_double_available, set_device, get_device, sync, get_backend_count, set_backend};
+pub use device::{get_version, info, device_count, is_double_available
+	, set_device, get_device, sync, get_backend_count, set_backend
+	, get_available_backends};
 mod device;
 
 pub use defines::{Aftype, AfError, AfBackend, ColorMap, YCCStd};


### PR DESCRIPTION
@9prady9 : Can you test opencl on linux? For some reason my linux box isn't building libafopencl. It should work as expected though. It **does** work fine on OSX though :)

```bash
     Running `target/debug/examples/unified`
There are 2 available backends
ArrayFire v3.2.0 (CPU, 64-bit Linux, build c607f62)
[0] Intel: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz Max threads(12) 
Create a 10-by-10 matrix of random floats on the compute device
No Name Array
[10 10 1 1]
    0.0000     0.3835     0.4175     0.9103     0.2470     0.7665     0.9047     0.5007     0.8278     0.2332 
    0.1315     0.5194     0.6868     0.7622     0.9826     0.4777     0.5045     0.3841     0.1254     0.3063 
    0.7556     0.8310     0.5890     0.2625     0.7227     0.2378     0.5163     0.2771     0.0159     0.3510 
    0.4587     0.0346     0.9304     0.0475     0.7534     0.2749     0.3190     0.9138     0.6885     0.5133 
    0.5328     0.0535     0.8462     0.7361     0.6515     0.3593     0.9866     0.5297     0.8682     0.5911 
    0.2190     0.5297     0.5269     0.3282     0.0727     0.1665     0.4940     0.4644     0.6295     0.8460 
    0.0470     0.6711     0.0920     0.6326     0.6316     0.4865     0.2661     0.9410     0.7362     0.4121 
    0.6789     0.0077     0.6539     0.7564     0.8847     0.8977     0.0907     0.0501     0.7254     0.8415 
    0.6793     0.3834     0.4160     0.9910     0.2727     0.9092     0.9478     0.7615     0.9995     0.2693 
    0.9347     0.0668     0.7012     0.3653     0.4364     0.0606     0.0737     0.7702     0.8886     0.4154 

ArrayFire v3.2.0 (CUDA, 64-bit Linux, build c607f62)
Platform: CUDA Toolkit 7.5, Driver: 352.39
[0] GeForce GTX TITAN X, 12285 MB, CUDA Compute 5.2
Create a 10-by-10 matrix of random floats on the compute device
No Name Array
[10 10 1 1]
    0.7402     0.7762     0.2080     0.3557     0.2849     0.9200     0.2674     0.9910     0.4942     0.1528 
    0.9210     0.2948     0.6110     0.7229     0.7793     0.1872     0.0208     0.8793     0.3031     0.0119 
    0.0390     0.7140     0.3073     0.2783     0.2133     0.1820     0.8331     0.9996     0.8094     0.1726 
    0.9690     0.3585     0.4156     0.6192     0.4131     0.5984     0.7218     0.2068     0.1293     0.4784 
    0.9251     0.6814     0.2343     0.5876     0.0328     0.7082     0.6087     0.4372     0.7832     0.8051 
    0.4464     0.2920     0.8793     0.3750     0.5360     0.0421     0.6301     0.3727     0.0732     0.6872 
    0.6673     0.3194     0.6462     0.2405     0.7214     0.7305     0.5298     0.4468     0.1236     0.3022 
    0.1099     0.8109     0.9264     0.4148     0.3546     0.9400     0.8127     0.2376     0.2229     0.8077 
    0.4702     0.1541     0.5786     0.0937     0.2527     0.8432     0.0593     0.0345     0.7420     0.4071 
    0.5132     0.4452     0.5538     0.6326     0.9847     0.6116     0.4797     0.7308     0.6273     0.7513 

OpenCL backend not available: Unkown Error
```

OSX Result:
``` bash
     Running `target/debug/examples/unified`
There are 3 available backends
ArrayFire v3.2.0 (CPU, 64-bit Mac OSX, build c607f62)
[0] Intel: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz Max threads(8)
Create a 10-by-10 matrix of random floats on the compute device
No Name Array
[10 10 1 1]
    0.0000     0.0895     0.2971     0.9362     0.6095     0.0840     0.5771     0.5042     0.9585     0.7989
    0.0850     0.5604     0.4261     0.4146     0.4323     0.1813     0.1639     0.4674     0.9908     0.5930
    0.6014     0.5822     0.8995     0.3085     0.5995     0.6167     0.6985     0.5790     0.1136     0.8967
    0.8916     0.8096     0.6530     0.5149     0.8449     0.5791     0.3348     0.6741     0.8706     0.2717
    0.9680     0.5919     0.9015     0.3954     0.4924     0.7393     0.4558     0.0934     0.6223     0.1980
    0.1897     0.5117     0.9615     0.7898     0.7728     0.3141     0.0762     0.0667     0.6727     0.2705
    0.5150     0.8766     0.1647     0.6891     0.0717     0.4388     0.1288     0.8327     0.6140     0.3964
    0.3980     0.9951     0.8580     0.5443     0.1919     0.4120     0.1745     0.3898     0.5877     0.0959
    0.2629     0.7262     0.9068     0.5924     0.2236     0.9089     0.4418     0.1909     0.1509     0.6481
    0.7435     0.9666     0.2940     0.0936     0.7804     0.9923     0.0373     0.1654     0.2550     0.6326

ArrayFire v3.1.1 (CUDA, 64-bit Mac OSX, build 2d75672)
Platform: CUDA Toolkit 7, Driver: CUDA Driver Version: 7000
[0] GeForce GT 750M, 2048 MB, CUDA Compute 3.0
Create a 10-by-10 matrix of random floats on the compute device
No Name Array
[10 10 1 1]
    0.7402     0.7762     0.2080     0.3557     0.2849     0.9200     0.2674     0.9910     0.4942     0.1528
    0.9210     0.2948     0.6110     0.7229     0.7793     0.1872     0.0208     0.8793     0.3031     0.0119
    0.0390     0.7140     0.3073     0.2783     0.2133     0.1820     0.8331     0.9996     0.8094     0.1726
    0.9690     0.3585     0.4156     0.6192     0.4131     0.5984     0.7218     0.2068     0.1293     0.4784
    0.9251     0.6814     0.2343     0.5876     0.0328     0.7082     0.6087     0.4372     0.7832     0.8051
    0.4464     0.2920     0.8793     0.3750     0.5360     0.0421     0.6301     0.3727     0.0732     0.6872
    0.6673     0.3194     0.6462     0.2405     0.7214     0.7305     0.5298     0.4468     0.1236     0.3022
    0.1099     0.8109     0.9264     0.4148     0.3546     0.9400     0.8127     0.2376     0.2229     0.8077
    0.4702     0.1541     0.5786     0.0937     0.2527     0.8432     0.0593     0.0345     0.7420     0.4071
    0.5132     0.4452     0.5538     0.6326     0.9847     0.6116     0.4797     0.7308     0.6273     0.7513

ArrayFire v3.2.0 (OpenCL, 64-bit Mac OSX, build c607f62)
[0] APPLE   : Iris Pro
-1- APPLE   : GeForce GT 750M
Create a 10-by-10 matrix of random floats on the compute device
No Name Array
[10 10 1 1]
    0.4107     0.6600     0.8395     0.9250     0.6530     0.8355     0.1033     0.9276     0.6742     0.2809
    0.8224     0.0764     0.1933     0.3063     0.5476     0.4878     0.2119     0.8662     0.9713     0.3084
    0.9518     0.0901     0.7270     0.9313     0.8577     0.2055     0.5955     0.3578     0.9878     0.1965
    0.1794     0.5933     0.0322     0.8684     0.8370     0.1794     0.3745     0.6263     0.0663     0.1459
    0.4198     0.1098     0.0012     0.6592     0.0618     0.5606     0.9165     0.9747     0.6043     0.2551
    0.0081     0.1046     0.8703     0.4387     0.4224     0.6767     0.9426     0.2002     0.5900     0.5746
    0.3775     0.8827     0.5259     0.3784     0.5293     0.6742     0.4817     0.2022     0.7482     0.3614
    0.3027     0.1647     0.1443     0.4002     0.0212     0.4523     0.9097     0.5389     0.2379     0.4471
    0.6456     0.8060     0.3253     0.4390     0.1103     0.1236     0.6821     0.5509     0.3121     0.0836
    0.5591     0.5938     0.5081     0.4718     0.4420     0.7924     0.6056     0.8180     0.8957     0.7878
```
fixes #29 