### PR TITLE
remove the lib directory dependency from conf and add a message for when AF_PATH is not set

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -23,6 +23,5 @@
     "boost_dir": "E:\\Libraries\\boost_1_56_0",
 
     "cuda_sdk": "/usr/local/cuda",
-    "opencl_sdk": "/usr",
-    "sdk_lib_dir": "lib64"
+    "opencl_sdk": "/usr"
 }


### PR DESCRIPTION
It's a little ridiculous that we don't check the lib dir. 
Added this logic (i.e. check lib64 first, then lib).

Also test results for when AF_PATH is not set is a little more meaningful now:
```bash
➜  arrayfire-rust git:(master) ✗ cargo run --verbose --example unified
   Compiling libc v0.1.12
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/libc-0.1.12/rust/src/liblibc/lib.rs --crate-name libc --crate-type lib -g --cfg feature=\"cargo-build\" --cfg feature=\"default\" -C metadata=29adb837ec836726 -C extra-filename=-29adb837ec836726 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -Awarnings`
   Compiling winapi v0.2.5
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/winapi-0.2.5/src/lib.rs --crate-name winapi --crate-type lib -g -C metadata=d88a8c018c340227 -C extra-filename=-d88a8c018c340227 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -Awarnings`
   Compiling rustc-serialize v0.3.16
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/rustc-serialize-0.3.16/src/lib.rs --crate-name rustc_serialize --crate-type lib -g -C metadata=7ff5bfc027146194 -C extra-filename=-7ff5bfc027146194 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -Awarnings`
   Compiling libc v0.2.2
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/libc-0.2.2/src/lib.rs --crate-name libc --crate-type lib -g --cfg feature=\"default\" -C metadata=540159808ccfa9ab -C extra-filename=-540159808ccfa9ab --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -Awarnings`
   Compiling winapi-build v0.1.1
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/winapi-build-0.1.1/src/lib.rs --crate-name build --crate-type lib -g -C metadata=304afb6bdff23d72 -C extra-filename=-304afb6bdff23d72 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -Awarnings`
   Compiling advapi32-sys v0.1.2
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/advapi32-sys-0.1.2/build.rs --crate-name build_script_build --crate-type bin -C prefer-dynamic -g --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/build/advapi32-sys-cfef7a1f30f1e5f6 --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern build=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libbuild-304afb6bdff23d72.rlib -Awarnings`
   Compiling kernel32-sys v0.2.1
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/kernel32-sys-0.2.1/build.rs --crate-name build_script_build --crate-type bin -C prefer-dynamic -g --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/build/kernel32-sys-35c1a745c861d23a --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern build=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libbuild-304afb6bdff23d72.rlib -Awarnings`
     Running `/Users/jramapuram/projects/arrayfire-rust/target/debug/build/advapi32-sys-cfef7a1f30f1e5f6/build-script-build`
     Running `/Users/jramapuram/projects/arrayfire-rust/target/debug/build/kernel32-sys-35c1a745c861d23a/build-script-build`
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/kernel32-sys-0.2.1/src/lib.rs --crate-name kernel32 --crate-type lib -g -C metadata=35c1a745c861d23a -C extra-filename=-35c1a745c861d23a --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern winapi=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libwinapi-d88a8c018c340227.rlib -Awarnings`
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/advapi32-sys-0.1.2/src/lib.rs --crate-name advapi32 --crate-type lib -g -C metadata=cfef7a1f30f1e5f6 -C extra-filename=-cfef7a1f30f1e5f6 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern winapi=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libwinapi-d88a8c018c340227.rlib -Awarnings`
   Compiling rand v0.3.12
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/rand-0.3.12/src/lib.rs --crate-name rand --crate-type lib -g -C metadata=204b49f864ff4762 -C extra-filename=-204b49f864ff4762 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern winapi=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libwinapi-d88a8c018c340227.rlib --extern libc=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/liblibc-540159808ccfa9ab.rlib --extern advapi32=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libadvapi32-cfef7a1f30f1e5f6.rlib -Awarnings`
   Compiling time v0.1.34
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/time-0.1.34/src/lib.rs --crate-name time --crate-type lib -g -C metadata=b8d9c9e7ca5bced7 -C extra-filename=-b8d9c9e7ca5bced7 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern libc=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/liblibc-540159808ccfa9ab.rlib --extern winapi=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libwinapi-d88a8c018c340227.rlib --extern kernel32=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/libkernel32-35c1a745c861d23a.rlib -Awarnings`
   Compiling arrayfire v3.2.0-rc0 (file:///Users/jramapuram/projects/arrayfire-rust)
     Running `rustc build.rs --crate-name build_script_build --crate-type bin -C prefer-dynamic -g --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/build/arrayfire-de40146cb4855a1d --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern rustc_serialize=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/librustc_serialize-7ff5bfc027146194.rlib`
   Compiling num v0.1.27
     Running `rustc /Users/jramapuram/.cargo/registry/src/github.com-0a35038f75765ae4/num-0.1.27/src/lib.rs --crate-name num --crate-type lib -g --cfg feature=\"default\" --cfg feature=\"rustc-serialize\" --cfg feature=\"rand\" --cfg feature=\"bigint\" --cfg feature=\"complex\" --cfg feature=\"rational\" -C metadata=397f282c1d72fe58 -C extra-filename=-397f282c1d72fe58 --out-dir /Users/jramapuram/projects/arrayfire-rust/target/debug/deps --emit=dep-info,link -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps -L dependency=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps --extern rand=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/librand-204b49f864ff4762.rlib --extern rustc_serialize=/Users/jramapuram/projects/arrayfire-rust/target/debug/deps/librustc_serialize-7ff5bfc027146194.rlib -Awarnings`
     Running `/Users/jramapuram/projects/arrayfire-rust/target/debug/build/arrayfire-de40146cb4855a1d/build-script-build`
Build failed, waiting for other jobs to finish...
failed to run custom build command for `arrayfire v3.2.0-rc0 (file:///Users/jramapuram/projects/arrayfire-rust)`
Process didn't exit successfully: `/Users/jramapuram/projects/arrayfire-rust/target/debug/build/arrayfire-de40146cb4855a1d/build-script-build` (exit code: 101)
--- stderr
thread '<main>' panicked at 'Error use_lib is defined, but AF_PATH is not defined', build.rs:350
```