### PR TITLE
Allow for backend swap during array drop

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -285,6 +285,12 @@ impl Clone for Array {
 /// To free resources when Array goes out of scope
 impl Drop for Array {
     fn drop(&mut self) {
+        let swap_code = set_backend(self.get_backend());
+        match swap_code {
+            Ok(_) => (),
+            Err(error) => panic!("Failed to swap backend during drop : {}", error),
+        }
+
         unsafe {
             let ret_val = af_release_array(self.handle);
             match ret_val {


### PR DESCRIPTION
This will automate the switching of backends for array drops.
I.e. if one has many different arrays such as on CPU/CUDA, etc this will help prevent any segfaults.