### PR TITLE
Add support for partialeq & debug to dim4

### DIFF
--- a/src/dim4.rs
+++ b/src/dim4.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::ops::Index;
 
 /// Dim4 is used to store [Array](./struct.Array.html) dimensions
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Dim4 {
     dims: [u64; 4],
 }


### PR DESCRIPTION
Very annoying doing:
```rust
if arr.dims().unwrap().get().clone() == arr2.dims().unwrap().get().clone() {}
```

Also debug offers:
```rust
println!("dims = {:?}", arr.dims().unwrap());
```