### PR TITLE
Added info_string

### DIFF
--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -7,6 +7,7 @@ use af::*;
 fn main() {
     set_device(0);
     info();
+    print!("Info String:\n{}", info_string(true));
 
     let num_rows: u64 = 5;
     let num_cols: u64 = 3;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,6 @@
 extern crate libc;
 
-use defines::AfError;
+use defines::{AfError, DType};
 use error::HANDLE_ERROR;
 use self::libc::{c_int, size_t, c_char, c_void};
 use std::ffi::CString;
@@ -22,7 +22,8 @@ extern {
     fn af_device_gc() -> c_int;
     fn af_sync(device: c_int) -> c_int;
 
-    fn af_free_host (ptr: *mut c_void) -> c_int;
+    fn af_alloc_host(elements: size_t, _type: DType) -> *mut c_void;
+    fn af_free_host(ptr: *mut c_void) -> c_int;
 }
 
 /// Get ArrayFire Version Number
@@ -76,7 +77,7 @@ pub fn info_string(verbose: bool) -> String {
         let err_val = af_info_string(&mut tmp, verbose);
         HANDLE_ERROR(AfError::from(err_val));
 
-        let result = CString::from_raw(tmp).into_string().unwrap();
+        let result = (*CString::from_raw(tmp)).to_str().unwrap().to_owned();
 
         let err_val = af_free_host(tmp as *mut c_void);
         HANDLE_ERROR(AfError::from(err_val));

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -72,7 +72,7 @@ pub fn info() {
 pub fn info_string(verbose: bool) -> String {
     let result: String;
     unsafe {
-        let mut tmp: *mut c_char = 0 as *mut c_char;
+        let mut tmp: *mut c_char = ::std::ptr::null_mut();
         let err_val = af_info_string(&mut tmp, verbose);
         HANDLE_ERROR(AfError::from(err_val));
         result = CStr::from_ptr(tmp).to_string_lossy().into_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use data::{select, selectl, selectr, replace, replace_scalar};
 pub use data::{range_t, iota_t, identity_t, constant_t};
 mod data;
 
-pub use device::{get_version, info, init, device_count, is_double_available, set_device, get_device};
+pub use device::{get_version, info, info_string, init, device_count, is_double_available, set_device, get_device};
 pub use device::{device_mem_info, print_mem_info, set_mem_step_size, get_mem_step_size, device_gc, sync};
 mod device;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,11 +6,18 @@ use defines::{SparseFormat, BinaryOp, RandomEngineType};
 use error::HANDLE_ERROR;
 use std::mem;
 use self::num::Complex;
-use self::libc::{uint8_t, c_int, size_t};
+use self::libc::{uint8_t, c_int, size_t, c_void};
+
+// This is private in array
+// use array::DimT;
+type DimT = self::libc::c_longlong;
 
 #[allow(dead_code)]
 extern {
     fn af_get_size_of(size: *mut size_t, aftype: uint8_t) -> c_int;
+
+    fn af_alloc_host(ptr: *mut *const c_void, bytes: DimT) -> c_int;
+    fn af_free_host(ptr: *mut c_void) -> c_int;
 }
 
 /// Get size, in bytes, of the arrayfire native type
@@ -20,6 +27,25 @@ pub fn get_size(value: DType) -> usize {
         let err_val = af_get_size_of(&mut ret_val as *mut size_t, value as uint8_t);
         HANDLE_ERROR(AfError::from(err_val));
         ret_val
+    }
+}
+
+/// Allocates space using Arrayfire allocator in host memory
+pub fn alloc_host<T>(elements: usize, _type: DType) -> *const T {
+    let ptr = 0 as *const T;
+    let bytes = (elements * get_size(_type)) as DimT;
+    unsafe {
+        let err_val = af_alloc_host(&mut (ptr as *const c_void), bytes);
+        HANDLE_ERROR(AfError::from(err_val));
+    }
+    ptr
+}
+
+/// Frees memory allocated by Arrayfire allocator in host memory
+pub fn free_host<T>(ptr: *mut T) {
+    unsafe {
+        let err_val = af_free_host(ptr as *mut c_void);
+        HANDLE_ERROR(AfError::from(err_val));
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -32,7 +32,7 @@ pub fn get_size(value: DType) -> usize {
 
 /// Allocates space using Arrayfire allocator in host memory
 pub fn alloc_host<T>(elements: usize, _type: DType) -> *const T {
-    let ptr = 0 as *const T;
+    let ptr: *const T = ::std::ptr::null();
     let bytes = (elements * get_size(_type)) as DimT;
     unsafe {
         let err_val = af_alloc_host(&mut (ptr as *const c_void), bytes);


### PR DESCRIPTION
I've just added the linking and interface bit for `af_info_string` (also `af_free_host` and `af_alloc_host`). However, I'm not a 100% sure whether I need to call `af_free_host` and whether I'm doing that correctly, so definitely someone should take a look at that. 

Following the discussion on the forum [here](https://users.rust-lang.org/t/c-char-to-str-or-string/9417/9) in order to make `Rust` copy the string into rust allocated space I'm using `to_str().to_owned()` rather than `into_string()` and freeing the arrayfire buffer.