### PR TITLE
Added `get_revision` and `device_info`

### DIFF
--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -8,6 +8,10 @@ fn main() {
     set_device(0);
     info();
     print!("Info String:\n{}", info_string(true));
+    println!("Arrayfire version: {:?}", get_version());
+    let (name, platform, toolkit, compute) = device_info();
+    print!("Name: {}\nPlatform: {}\nToolkit: {}\nCompute: {}\n", name, platform, toolkit, compute);
+    println!("Revision: {}", get_revision());
 
     let num_rows: u64 = 5;
     let num_cols: u64 = 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use data::{select, selectl, selectr, replace, replace_scalar};
 pub use data::{range_t, iota_t, identity_t, constant_t};
 mod data;
 
-pub use device::{get_version, info, info_string, init, device_count, is_double_available, set_device, get_device};
+pub use device::{get_version, get_revision, info, info_string, device_info, init, device_count, is_double_available, set_device, get_device};
 pub use device::{device_mem_info, print_mem_info, set_mem_step_size, get_mem_step_size, device_gc, sync};
 mod device;
 


### PR DESCRIPTION
Sorry, this should have been part of the previous, but was a bit busy.
One caveat is that I assumed that the commit string is truly static, so I return `Cow<'static, str>`. Also, I notice that the name of the platform has underscores `Intel(R)_Core(TM)_i7-4600U_CPU_@ 2.10GHz` so the question is should those be replaced by spaces or kept like that.