### PR TITLE
Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ You can find the most recent updated documentation [here](http://arrayfire.githu
 
 ## Supported platforms
 
-- Linux and OSX: The bindings have been tested with Rust 1.x.
-- Windows: Rust 1.5 (MSVC ABI) is the first version that works with our bindings and ArrayFire library(built using MSVC compiler).
-
-We recommend using Rust 1.5 and higher.
-
-Rust 1.8 stabilized the traits for compound assignment operations. These are automatically enabled
-based on the rust version you are using.
+Linux, Windows and OSX. We recommend using Rust 1.15.1 or higher.
 
 ## Use from Crates.io [![](http://meritbadge.herokuapp.com/arrayfire)](https://crates.io/crates/arrayfire)
 

--- a/src/arith/mod.rs
+++ b/src/arith/mod.rs
@@ -255,6 +255,17 @@ macro_rules! overloaded_binary_func {
         ///
         /// An Array with results of the binary operation.
         ///
+        /// In the case of comparison operations such as the following, the type of output
+        /// Array is [DType::B8](./enum.DType.html). To retrieve the results of such boolean output
+        /// to host, an array of 8-bit wide types(eg. u8, i8) should be used since ArrayFire's internal
+        /// implementation uses char for boolean.
+        ///
+        /// * [gt](./fn.gt.html)
+        /// * [lt](./fn.lt.html)
+        /// * [ge](./fn.ge.html)
+        /// * [le](./fn.le.html)
+        /// * [eq](./fn.eq.html)
+        ///
         ///# Note
         ///
         /// The trait `Convertable` essentially translates to a scalar native type on rust or Array.

--- a/src/array.rs
+++ b/src/array.rs
@@ -308,7 +308,10 @@ impl Array {
     }
 
     /// Copies the data from the Array to the mutable slice `data`
-    pub fn host<T>(&self, data: &mut [T]) {
+    pub fn host<T: HasAfEnum>(&self, data: &mut [T]) {
+        if data.len() != self.elements() {
+            HANDLE_ERROR(AfError::ERR_SIZE);
+        }
         unsafe {
             let err_val = af_get_data_ptr(data.as_mut_ptr() as *mut c_void, self.handle as AfArray);
             HANDLE_ERROR(AfError::from(err_val));

--- a/src/array.rs
+++ b/src/array.rs
@@ -233,12 +233,12 @@ impl Array {
     }
 
     /// Returns the number of elements in the Array
-    pub fn elements(&self) -> i64 {
+    pub fn elements(&self) -> usize {
         unsafe {
             let mut ret_val: i64 = 0;
             let err_val = af_get_elements(&mut ret_val as MutAfArray, self.handle as AfArray);
             HANDLE_ERROR(AfError::from(err_val));
-            ret_val
+            ret_val as usize
         }
     }
 

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -126,6 +126,8 @@ pub fn gradient(input: &Array) -> (Array, Array) {
 
 /// Load Image into Array
 ///
+/// Only, Images with 8/16/32 bits per channel can be loaded using this function.
+///
 /// # Parameters
 ///
 /// - `filename` is aboslute path of the image to be loaded.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://arrayfire.com/docs/rust")]
 #![warn(missing_docs)]
+#![allow(non_camel_case_types)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,12 +9,12 @@ use self::num::Complex;
 use self::libc::{uint8_t, c_int, size_t, c_void};
 
 pub type AfArray       = self::libc::c_longlong;
+pub type AfIndex       = self::libc::c_longlong;
 pub type CellPtr       = *const self::libc::c_void;
 pub type Complex32     = Complex<f32>;
 pub type Complex64     = Complex<f64>;
 pub type DimT          = self::libc::c_longlong;
 pub type Feat          = *const self::libc::c_void;
-pub type IndexT        = self::libc::c_longlong;
 pub type Intl          = self::libc::c_longlong;
 pub type MutAfArray    = *mut self::libc::c_longlong;
 pub type MutAfIndex    = *mut self::libc::c_longlong;


### PR DESCRIPTION
- Fixes #135 
- Fixes #124 - Added Array::new_empty that lets you create empty Arrays.
- Fixes #138 
- Fixes #136 - Updated documentation of comparison operation functions indicating the return Array type.