### PR TITLE
Take a shared reference instead of ownership in random::random_uniform() and random::random_normal()

### DIFF
--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -217,7 +217,7 @@ pub fn set_default_random_engine_type(rtype: RandomEngineType) {
 /// # Return Values
 ///
 /// An Array with uniform numbers generated using random engine
-pub fn random_uniform<T: HasAfEnum>(dims: Dim4, engine: RandomEngine) -> Array {
+pub fn random_uniform<T: HasAfEnum>(dims: Dim4, engine: &RandomEngine) -> Array {
     unsafe {
         let aftype = T::get_af_dtype();
         let mut temp : i64 = 0;
@@ -239,7 +239,7 @@ pub fn random_uniform<T: HasAfEnum>(dims: Dim4, engine: RandomEngine) -> Array {
 /// # Return Values
 ///
 /// An Array with normal numbers generated using random engine
-pub fn random_normal<T: HasAfEnum>(dims: Dim4, engine: RandomEngine) -> Array {
+pub fn random_normal<T: HasAfEnum>(dims: Dim4, engine: &RandomEngine) -> Array {
     unsafe {
         let aftype = T::get_af_dtype();
         let mut temp : i64 = 0;


### PR DESCRIPTION
Fixes #162 

Please let me know if, as per my question in #162, I'm misunderstanding some subtlety and attempting to change intended behaviour.