### PR TITLE
Update macros.rs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -86,7 +86,7 @@ macro_rules! mem_info {
 // Using macro to implement join many wrapper
 #[macro_export]
 macro_rules! join_many {
-    [$dim: expr; $($x:ident),+] => {
+    [$dim: expr; $($x:expr),+] => {
         {
             let mut temp_vec = Vec::new();
             $(
@@ -110,7 +110,7 @@ macro_rules! join_many {
 ///
 #[macro_export]
 macro_rules! af_print {
-    [$msg: expr, $x: ident] => {
+    [$msg: expr, $x: expr] => {
         {
             print_gen(String::from($msg), &$x, Some(4));
         }
@@ -120,7 +120,7 @@ macro_rules! af_print {
 /// Evaluate arbitrary number of arrays
 #[macro_export]
 macro_rules! eval {
-    [$($x:ident),+] => {
+    [$($x:expr),+] => {
         {
             let mut temp_vec = Vec::new();
             $(


### PR DESCRIPTION
Updated macros af_print, join_many and eval to work with expressions instead of identifiers.
Before the update, code like this:
```
let a = arrayfire::randu(Dim4::new(&[3, 3, 1, 1]));
af_print!("A transposed: ", arrayfire::transpose(&a, false));
```
Would not compile, and should have been written like this: 
```
let a = arrayfire::randu(Dim4::new(&[3, 3, 1, 1]));
let a_T =  arrayfire::transpose(&a, false);
af_print!("A transposed: ", a_T);
```
The update fixes this issue