### PR TITLE
Implement (Scalar +-*/ Array)

### DIFF
--- a/src/arith/mod.rs
+++ b/src/arith/mod.rs
@@ -671,6 +671,7 @@ where
 
 macro_rules! arith_scalar_func {
     ($rust_type: ty, $op_name:ident, $fn_name: ident) => {
+        // Implement (&Array<T> op_name rust_type)
         impl<'f, T> $op_name<$rust_type> for &'f Array<T>
         where
             T: HasAfEnum + ImplicitPromote<$rust_type>,
@@ -685,6 +686,7 @@ macro_rules! arith_scalar_func {
             }
         }
 
+        // Implement (Array<T> op_name rust_type)
         impl<T: HasAfEnum> $op_name<$rust_type> for Array<T>
         where
             T: HasAfEnum + ImplicitPromote<$rust_type>,
@@ -696,6 +698,34 @@ macro_rules! arith_scalar_func {
             fn $fn_name(self, rhs: $rust_type) -> Self::Output {
                 let temp = rhs.clone();
                 $fn_name(&self, &temp, false)
+            }
+        }
+
+        // Implement (rust_type op_name &Array<T>)
+        impl<'f, T> $op_name<&'f Array<T>> for $rust_type
+        where
+            T: HasAfEnum + ImplicitPromote<$rust_type>,
+            $rust_type: HasAfEnum + ImplicitPromote<T>,
+            <$rust_type as ImplicitPromote<T>>::Output: HasAfEnum,
+        {
+            type Output = Array<<$rust_type as ImplicitPromote<T>>::Output>;
+
+            fn $fn_name(self, rhs: &'f Array<T>) -> Self::Output {
+                $fn_name(&self, rhs, false)
+            }
+        }
+
+        // Implement (rust_type op_name Array<T>)
+        impl<T> $op_name<Array<T>> for $rust_type
+        where
+            T: HasAfEnum + ImplicitPromote<$rust_type>,
+            $rust_type: HasAfEnum + ImplicitPromote<T>,
+            <$rust_type as ImplicitPromote<T>>::Output: HasAfEnum,
+        {
+            type Output = Array<<$rust_type as ImplicitPromote<T>>::Output>;
+
+            fn $fn_name(self, rhs: Array<T>) -> Self::Output {
+                $fn_name(&self, &rhs, false)
             }
         }
     };


### PR DESCRIPTION
Hi @9prady9,

I implemented the overloaded operators as you suggested.  I don't know what your testing standards are, so I've only done a minimal amount of testing by hand.

Also, it turns out that the function which I previously tried to add (`scalar`) is already implemented as the `convert` function, so I could have made the equation `1 / Array` work with `1.convert() / Array`

I hope this helps!