### PR TITLE
Address all clippy warns/errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ libc = "0.2"
 num  = "0.2"
 lazy_static = "1.0"
 
+[dev-dependencies]
+float-cmp = "0.6.0"
+
 [build-dependencies]
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -49,7 +49,7 @@ fn main() {
     //Index array using array and sequence
     let seq4gen = Seq::new(0u32, 2, 1);
 
-    let mut idxrs = Indexer::new();
+    let mut idxrs = Indexer::default();
     idxrs.set_index(&indices, 0, None);
     idxrs.set_index(&seq4gen, 1, Some(false));
 

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -23,16 +23,16 @@ fn main() {
     let man = load_image::<f32>(format!("{}/man.jpg", assets_dir.display()), false);
     let hst = histogram(&man, 256, 0.0, 255.0);
 
-    let disp_img = div(&man, &constant(255 as f32, man.dims()), false);
+    let disp_img = div(&man, &constant(255_f32, man.dims()), false);
 
     loop {
         img_wnd.draw_image(&disp_img, None);
         hst_wnd.draw_hist(&hst, 0.0, 255.0, None);
 
-        if img_wnd.is_closed() == true {
+        if img_wnd.is_closed() {
             break;
         }
-        if hst_wnd.is_closed() == true {
+        if hst_wnd.is_closed() {
             break;
         }
     }

--- a/examples/snow.rs
+++ b/examples/snow.rs
@@ -13,7 +13,7 @@ fn main() {
     loop {
         wnd.draw_image(&randu::<f32>(dims), None);
 
-        if wnd.is_closed() == true {
+        if wnd.is_closed() {
             break;
         }
     }

--- a/src/arith/mod.rs
+++ b/src/arith/mod.rs
@@ -840,7 +840,7 @@ mod op_assign {
                 #[allow(unused_variables)]
                 fn $fn_name(&mut self, rhs: Array<B>) {
                     let tmp_seq = Seq::<f32>::default();
-                    let mut idxrs = Indexer::new();
+                    let mut idxrs = Indexer::default();
                     for n in 0..self.numdims() {
                         idxrs.set_index(&tmp_seq, n, Some(false));
                     }
@@ -872,7 +872,7 @@ mod op_assign {
                 #[allow(unused_variables)]
                 fn $fn_name(&mut self, rhs: Array<B>) {
                     let tmp_seq = Seq::<f32>::default();
-                    let mut idxrs = Indexer::new();
+                    let mut idxrs = Indexer::default();
                     for n in 0..self.numdims() {
                         idxrs.set_index(&tmp_seq, n, Some(false));
                     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,11 +1,11 @@
 extern crate libc;
 
-use self::libc::{c_int, c_uint, uint8_t};
+use self::libc::{c_int, c_uint};
 use crate::defines::{AfError, Backend};
 use crate::error::HANDLE_ERROR;
 
 extern "C" {
-    fn af_set_backend(bknd: uint8_t) -> c_int;
+    fn af_set_backend(bknd: u8) -> c_int;
     fn af_get_backend_count(num_backends: *mut c_uint) -> c_int;
     fn af_get_available_backends(backends: *mut c_int) -> c_int;
     fn af_get_active_backend(backend: *mut c_int) -> c_int;
@@ -18,7 +18,7 @@ extern "C" {
 /// - `backend` to which to switch to
 pub fn set_backend(backend: Backend) {
     unsafe {
-        let err_val = af_set_backend(backend as uint8_t);
+        let err_val = af_set_backend(backend as u8);
         HANDLE_ERROR(AfError::from(err_val));
     }
 }

--- a/src/defines.rs
+++ b/src/defines.rs
@@ -370,7 +370,7 @@ pub enum MomentType {
     /// Central moment of order (1 + 1)
     M11 = 8, // 1<<3
     /// All central moments of order (0,0), (0,1), (1,0) and (1,1)
-    FIRST_ORDER = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3,
+    FIRST_ORDER = 1 | 1 << 1 | 1 << 2 | 1 << 3,
 }
 
 /// Sparse storage format type

--- a/src/dim4.rs
+++ b/src/dim4.rs
@@ -30,7 +30,7 @@ impl Default for Dim4 {
 impl Index<usize> for Dim4 {
     type Output = u64;
 
-    fn index<'a>(&'a self, _index: usize) -> &'a u64 {
+    fn index(&self, _index: usize) -> &u64 {
         &self.dims[_index]
     }
 }
@@ -65,7 +65,9 @@ impl Dim4 {
     /// let dims = Dim4::new(&[4, 4, 2, 1]);
     /// ```
     pub fn new(dims: &[u64; 4]) -> Self {
-        Self { dims: dims.clone() }
+        Self {
+            dims: [dims[0], dims[1], dims[2], dims[3]],
+        }
     }
 
     /// Get the number of elements represented by Dim4 object

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,7 @@ lazy_static! {
 /// }
 /// ```
 #[allow(unused_must_use)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn register_error_handler(cb_value: Callback) {
     let mut gaurd = match ERROR_HANDLER_LOCK.write() {
         Ok(g) => g,
@@ -87,6 +88,7 @@ pub fn register_error_handler(cb_value: Callback) {
 }
 
 #[allow(non_snake_case)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn HANDLE_ERROR(error_code: AfError) {
     let gaurd = match ERROR_HANDLER_LOCK.read() {
         Ok(g) => g,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -212,6 +212,7 @@ impl Window {
     ///
     /// Window Object
     #[allow(unused_mut)]
+    #[allow(clippy::match_wild_err_arm)]
     pub fn new(width: i32, height: i32, title: String) -> Self {
         unsafe {
             let mut temp: u64 = 0;
@@ -472,6 +473,7 @@ impl Window {
     /// - `exact` indicates if the exact min/max values from `xrange`, `yrange` and `zrange`
     ///    are to extracted. If exact is false then the most significant digit is rounded up
     ///    to next power of 2 and the magnitude remains the same.
+    #[allow(clippy::too_many_arguments)]
     pub fn set_axes_limits_3d(
         &mut self,
         xmin: f32,
@@ -890,6 +892,7 @@ impl Window {
     /// - `zdirs` is an Array containing direction component of z coord
     /// - `title` parameter has effect only in multiview mode, where this string
     ///    is displayed as the respective cell/view title.
+    #[allow(clippy::too_many_arguments)]
     pub fn draw_vector_field3<T>(
         &self,
         xpnts: &Array<T>,

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -239,6 +239,7 @@ where
 ///
 /// An Array with pixel values loaded from the image
 #[allow(unused_mut)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn load_image<T>(filename: String, is_color: bool) -> Array<T>
 where
     T: HasAfEnum + RealNumber,
@@ -282,6 +283,7 @@ where
 ///
 /// An Array with pixel values loaded from the image
 #[allow(unused_mut)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn load_image_native<T>(filename: String) -> Array<T>
 where
     T: HasAfEnum + ImageNativeType,
@@ -309,6 +311,7 @@ where
 /// - `filename` is the abolute path(includes filename) at which input Array is going to be saved
 /// - `input` is the Array to be stored into the image file
 #[allow(unused_mut)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn save_image<T>(filename: String, input: &Array<T>)
 where
     T: HasAfEnum + RealNumber,
@@ -340,6 +343,7 @@ where
 /// - `filename` is name of file to be saved
 /// - `input` is the Array to be saved. Should be U8 for saving 8-bit image, U16 for 16-bit image, and F32 for 32-bit image.
 #[allow(unused_mut)]
+#[allow(clippy::match_wild_err_arm)]
 pub fn save_image_native<T>(filename: String, input: &Array<T>)
 where
     T: HasAfEnum + ImageNativeType,
@@ -1273,6 +1277,7 @@ hsvrgb_func_def!("RGB to HSV color space conversion", rgb2hsv, af_rgb2hsv);
 /// 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34  0  0  0  0  0
 /// 16 17 18 19  0 21 22 23 24  0 26 27 28 29  0 31 32 33 34  0  0  0  0  0  0
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn unwrap<T: HasAfEnum>(
     input: &Array<T>,
     wx: i64,
@@ -1324,6 +1329,7 @@ pub fn unwrap<T: HasAfEnum>(
 /// # Return Values
 ///
 /// Image(Array) created from unwrapped Image(Array)
+#[allow(clippy::too_many_arguments)]
 pub fn wrap<T: HasAfEnum>(
     input: &Array<T>,
     ox: i64,

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -38,11 +38,7 @@ impl<T: fmt::Display> fmt::Display for Seq<T> {
 impl<T: Copy> Seq<T> {
     /// Create a `Seq` that goes from `begin` to `end` at a step size of `step`
     pub fn new(begin: T, end: T, step: T) -> Self {
-        Self {
-            begin: begin,
-            end: end,
-            step: step,
-        }
+        Self { begin, end, step }
     }
 
     /// Get begin index of Seq

--- a/tests/error_handler.rs
+++ b/tests/error_handler.rs
@@ -41,7 +41,6 @@ fn check_error_handler_mutation() {
                         _ => panic!("Impossible scenario"),
                     }
                 })
-                .ok()
                 .expect("Failed to launch a thread")
         })
         .collect::<Vec<_>>();

--- a/tests/scalar_arith.rs
+++ b/tests/scalar_arith.rs
@@ -1,4 +1,5 @@
 use ::arrayfire::*;
+use float_cmp::approx_eq;
 
 #[allow(non_snake_case)]
 #[test]
@@ -15,5 +16,5 @@ fn check_scalar_arith() {
     let scalar_res = all_true_all(&scalar_res_comp);
     let res = all_true_all(&res_comp);
 
-    assert_eq!(scalar_res.0, res.0);
+    assert!(approx_eq!(f64, scalar_res.0, res.0, ulps = 2));
 }


### PR DESCRIPTION
There is one exception however - rust wrapper of arrayfire
panics whenever string arguments fail for whatever reason. In
such cases, we catch all errors to call `panic!`. This is one
lint that has been skipped.

Partially addresses #37 