### PR TITLE
Enable thread-safety marker traits for Structs

### DIFF
--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -14,9 +14,16 @@ extern "C" {
 }
 
 /// RAII construct to manage ArrayFire events
+///
+/// ## Sharing Across Threads
+///
+/// While sharing an Event with other threads, just move it across threads.
 pub struct Event {
     event_handle: af_event,
 }
+
+unsafe impl Send for Event {}
+// No borrowed references are to be shared for Events, hence no sync trait
 
 impl Default for Event {
     fn default() -> Self {
@@ -72,5 +79,83 @@ impl Drop for Event {
                 _ => panic!("Failed to delete event resources: {}", ret_val),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::arith::pow;
+    use super::super::device::{info, set_device};
+    use super::super::event::Event;
+    use crate::{af_print, randu};
+    use std::sync::mpsc;
+    use std::thread;
+
+    #[test]
+    fn event_block() {
+        // This code example will try to compute the following expression
+        // using data-graph approach using threads, evens for illustration.
+        //
+        // (a * (b + c))^(d - 2)
+        //
+        // ANCHOR: event_block
+
+        // Set active GPU/device on main thread on which
+        // subsequent Array objects are created
+        set_device(0);
+        info();
+
+        let a = randu!(10, 10);
+        let b = randu!(10, 10);
+        let c = randu!(10, 10);
+        let d = randu!(10, 10);
+
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            set_device(0);
+
+            let add_event = Event::default();
+
+            let add_res = b + c;
+
+            add_event.mark();
+            tx.send((add_res, add_event)).unwrap();
+
+            thread::sleep(std::time::Duration::new(10, 0));
+
+            let sub_event = Event::default();
+
+            let sub_res = d - 2;
+
+            sub_event.mark();
+            tx.send((sub_res, sub_event)).unwrap();
+        });
+
+        let (add_res, add_event) = rx.recv().unwrap();
+
+        println!("Got first message, waiting for addition result ...");
+        thread::sleep(std::time::Duration::new(5, 0));
+        // Perhaps, do some other tasks
+        add_event.block();
+
+        println!("Got addition result, now scaling it ... ");
+        let scaled = a * add_res;
+
+        let (sub_res, sub_event) = rx.recv().unwrap();
+
+        println!("Got message, waiting for subtraction result ...");
+        thread::sleep(std::time::Duration::new(5, 0));
+        // Perhaps, do some other tasks
+        sub_event.block();
+
+        let fin_res = pow(&scaled, &sub_res, false);
+
+        af_print!(
+            "Final result of the expression: ((a * (b + c))^(d - 2))",
+            &fin_res
+        );
+
+        // ANCHOR_END: event_block
     }
 }

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -51,6 +51,11 @@ extern "C" {
 
 /// Struct to manage an array of resources of type `af_indexer_t`(ArrayFire C struct)
 ///
+/// ## Sharing Across Threads
+///
+/// While sharing an Indexer object with other threads, just move it across threads. At the
+/// moment, one cannot share borrowed references across threads.
+///
 /// # Examples
 ///
 /// Given below are examples illustrating correct and incorrect usage of Indexer struct.
@@ -107,6 +112,8 @@ pub struct Indexer<'object> {
     count: usize,
     marker: PhantomData<&'object ()>,
 }
+
+unsafe impl<'object> Send for Indexer<'object> {}
 
 /// Trait bound indicating indexability
 ///

--- a/src/core/random.rs
+++ b/src/core/random.rs
@@ -104,9 +104,20 @@ data_gen_def!(
 /// Random number generator engine
 ///
 /// This is a wrapper for ArrayFire's native random number generator engine.
+///
+/// ## Sharing Across Threads
+///
+/// While sharing this object with other threads, there is no need to wrap
+/// this in an Arc object unless only one such object is required to exist.
+/// The reason being that ArrayFire's internal details that are pointed to
+/// by the RandoMEngine handle are appropriately reference counted in thread safe
+/// manner. However, if you need to modify RandomEngine object, then please do wrap
+/// the object using a Mutex or Read-Write lock.
 pub struct RandomEngine {
     handle: af_random_engine,
 }
+
+unsafe impl Send for RandomEngine {}
 
 /// Used for creating RandomEngine object from native resource id
 impl From<af_random_engine> for RandomEngine {

--- a/src/vision/mod.rs
+++ b/src/vision/mod.rs
@@ -114,9 +114,21 @@ extern "C" {
 /// - Scores of the features
 /// - Orientations of the features
 /// - Sizes of the features
+///
+/// ## Sharing Across Threads
+///
+/// While sharing this object with other threads, there is no need to wrap
+/// this in an Arc object unless only one such object is required to exist.
+/// The reason being that ArrayFire's internal details that are pointed to
+/// by the features handle are appropriately reference counted in thread safe
+/// manner. However, if these features are to be edited, then please do wrap
+/// the object using a Mutex or Read-Write lock.
 pub struct Features {
     feat: af_features,
 }
+
+unsafe impl Send for Features {}
+unsafe impl Sync for Features {}
 
 macro_rules! feat_func_def {
     ($doc_str: expr, $fn_name: ident, $ffi_name: ident) => (

--- a/tutorials-book/src/SUMMARY.md
+++ b/tutorials-book/src/SUMMARY.md
@@ -7,3 +7,4 @@
 - [Configuring ArrayFire Runtime Environment](./configuring_arrayfire_environment.md)
 - [Interoperability with CUDA](./cuda-interop.md)
 - [Interoperability with OpenCL](./opencl-interop.md)
+- [Multhi-Threading](./multi-threading.md)

--- a/tutorials-book/src/multi-threading.md
+++ b/tutorials-book/src/multi-threading.md
@@ -1,0 +1,56 @@
+# ArrayFire in Threaded Applications
+
+In this chapter, we will looking at how to use ArrayFire in multi-threaded programs. We shall
+go over the details in the following order.
+
+- [Move an Array to thread](#move-an-array-to-thread)
+- [Read Array from Multiple threads](#read-array-from-multiple-threads)
+- [Write to Array from Multiple threads](#write-to-array-from-multiple-threads)
+- [Write to single Array using Channel](#write-to-single-array-using-channel)
+
+## Move an Array to thread
+
+In this section, we are going to create an Array on main thread and move it to a child thread,
+modify it and then print it from the child thread.
+
+```rust,noplaypen
+{{#include ../../src/core/array.rs:move_array_to_thread}}
+```
+
+## Read Array from Multiple threads
+
+Now, let's expand the earlier example to do a bunch of arithmetic operations in parallel on
+multiple threads using the same Array objects.
+
+```rust,noplaypen
+{{#include ../../src/core/array.rs:read_from_multiple_threads}}
+```
+
+Given below is the definition of the enum `Op` we used in the example for illustration simplicity.
+```rust,noplaypen
+{{#include ../../src/core/array.rs:multiple_threads_enum_def}}
+```
+
+## Write to Array from Multiple threads
+
+Let us further expand the earlier example by accumulating the results of the arithmetic operations
+into a single Array object.
+
+The code will differ from earlier section in couple of locations:
+
+- In the main thread, we wrap the accumulating Array in a read-write lock (`std::sync::RwLock`)
+  which is in turn wrapped in an atomically reference counted counter a.k.a `std::sync::Arc`.
+- In the children threads, we use the guarded objects returned by RwLock's write method to access
+  the accumulator Array.
+
+```rust,noplaypen
+{{#include ../../src/core/array.rs:access_using_rwlock}}
+```
+
+## Write to single Array using Channel
+
+In this section, we shall modify the example to use channel instead of data sharing.
+
+```rust,noplaypen
+{{#include ../../src/core/array.rs:accum_using_channel}}
+```


### PR DESCRIPTION
Added a new threading tutorial with code examples illustrating how to share Array across threads.