### PR TITLE
Avoid memory allocation in reorder_v2

### DIFF
--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -568,7 +568,7 @@ pub fn reorder_v2<T>(
 where
     T: HasAfEnum,
 {
-    let mut new_axes = vec![0, 1, 2, 3];
+    let mut new_axes = [0, 1, 2, 3];
     new_axes[0] = new_axis0;
     new_axes[1] = new_axis1;
     match next_axes {


### PR DESCRIPTION
A tiny change to avoid an unnecessary heap allocation in `reorder_v2`.

First time contributor, just wanted to say thank you for the project. It's awesome to have such a useful and powerful numerical library with Rust bindings :100: