### PR TITLE
Seal HasAfEnum, Fromf64 and extended traits

### DIFF
--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -119,6 +119,25 @@ impl From<u32> for ColorMap {
     }
 }
 
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for num::complex::Complex<f32> {}
+    impl Sealed for num::complex::Complex<f64> {}
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+    impl Sealed for bool {}
+    impl Sealed for u8 {}
+    impl Sealed for i16 {}
+    impl Sealed for u16 {}
+    impl Sealed for half::f16 {}
+    impl Sealed for i32 {}
+    impl Sealed for u32 {}
+    impl Sealed for i64 {}
+    impl Sealed for u64 {}
+    impl Sealed for usize {}
+}
+
 /// Types of the data that can be generated using ArrayFire data generation functions.
 ///
 /// The trait HasAfEnum has been defined internally for the following types. We strongly suggest
@@ -139,7 +158,7 @@ impl From<u32> for ColorMap {
 /// - i16
 /// - u16
 ///
-pub trait HasAfEnum {
+pub trait HasAfEnum: private::Sealed {
     /// This type alias points to `Self` always.
     type InType: HasAfEnum;
     /// This type alias points to the data type used to hold real part of a
@@ -795,7 +814,7 @@ impl BitOr for MatProp {
 /// Trait to convert reduction's scalar output to appropriate output type
 ///
 /// This is an internal trait and ideally of no use to user usecases.
-pub trait Fromf64 {
+pub trait Fromf64: private::Sealed {
     /// Convert to target type from a double precision value
     fn fromf64(value: f64) -> Self;
 }
@@ -837,7 +856,7 @@ impl IndexableType for u16 {}
 impl IndexableType for u8 {}
 
 /// Trait qualifier for given type indicating computability of covariance
-pub trait IntegralType {}
+pub trait IntegralType: HasAfEnum {}
 
 impl IntegralType for i64 {}
 impl IntegralType for u64 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@
 //!
 //! Please go through our [tutorials](http://arrayfire.org/arrayfire-rust/book/index.html) book for
 //! more explanations on how to use ArrayFire to speedup your code.
+//!
+//! Note that the public traits on arrayfire-rust crate aren't meant to be implemented for user
+//! defined types. If attempted, rust compiler will throw an error.
 
 #![doc(
     html_logo_url = "http://www.arrayfire.com/logos/arrayfire_logo_symbol.png",


### PR DESCRIPTION
This prevents users from adding their own implementations for traits defined by ArrayFire Rust crate to help ease using arrayfire.

This shouldn't break any User code as long as user code is not using our crate's traits made public for for writing generic functions that can take `Array`s