### PR TITLE
Format debug trait output

### DIFF
--- a/src/core/array.rs
+++ b/src/core/array.rs
@@ -890,13 +890,24 @@ where
     T: HasAfEnum,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut vec = vec![T::default(); self.elements()];
-        self.host(&mut vec);
-        f.debug_struct("Array")
-            .field("dtype", &self.get_type())
-            .field("shape", &self.dims())
-            .field("data", &vec)
-            .finish()
+        if f.alternate() {
+            let mut vec = vec![T::default(); self.elements()];
+            self.host(&mut vec);
+            f.debug_struct("Array")
+                .field("dtype", &self.get_type())
+                .field("shape", &self.dims())
+                .field("strides", &self.strides())
+                .field("offset", &self.offset())
+                .field("device_id", &self.get_device_id())
+                .field("data", &vec)
+                .finish()
+        } else {
+            f.debug_struct("Array")
+                .field("dtype", &self.get_type())
+                .field("shape", &self.dims())
+                .field("af_array", unsafe { &self.get() })
+                .finish()
+        }
     }
 }
 

--- a/src/core/dim4.rs
+++ b/src/core/dim4.rs
@@ -64,13 +64,13 @@ impl IndexMut<usize> for Dim4 {
 /// use arrayfire::Dim4;
 ///
 /// let dims = Dim4::new(&[4, 4, 2, 1]);
-/// println!("0th Dimension length is {}", dims[0]); // -> 4
+/// println!("Shape is {}", dims); // -> [4, 4, 2, 1]
 /// ```
 impl fmt::Display for Dim4 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[{} {} {} {}]",
+            "[{}, {}, {}, {}]",
             self.dims[0], self.dims[1], self.dims[2], self.dims[3]
         )
     }

--- a/src/core/dim4.rs
+++ b/src/core/dim4.rs
@@ -5,7 +5,7 @@ use std::ops::{Index, IndexMut};
 use serde::{Deserialize, Serialize};
 
 /// Dim4 is used to store [Array](./struct.Array.html) dimensions
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "afserde", derive(Serialize, Deserialize))]
 pub struct Dim4 {
     dims: [u64; 4],
@@ -67,6 +67,26 @@ impl IndexMut<usize> for Dim4 {
 /// println!("Shape is {}", dims); // -> [4, 4, 2, 1]
 /// ```
 impl fmt::Display for Dim4 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "[{}, {}, {}, {}]",
+            self.dims[0], self.dims[1], self.dims[2], self.dims[3]
+        )
+    }
+}
+
+/// Debug trait implementation for Dim4 objects
+///
+/// # Examples
+///
+/// ```rust
+/// use arrayfire::Dim4;
+///
+/// let dims = Dim4::new(&[4, 4, 2, 1]);
+/// println!("Shape is {:?}", dims); // -> {4, 4, 2, 1}
+/// ```
+impl fmt::Debug for Dim4 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,


### PR DESCRIPTION
Code to illustrate the debug output
```rust
    let a = randu!(3, 3);
    let b = randu!(3, 3);

    af_print!("a", a);

    println!("a {:?}", &a);
    println!("a {:#?}", &a);
    println!("b {:?}", &b);
    println!("b {:#?}", &b);
```

Sample Output
```
a
[3 3 1 1]
    0.6010     0.2126     0.2864 
    0.0278     0.0655     0.3410 
    0.9806     0.5497     0.7509 

a Array { dtype: F32, shape: [3, 3, 1, 1], af_array: 0x560e508ba330 }
a Array {
    dtype: F32,
    shape: [3, 3, 1, 1],
    data: [
        0.6009535,
        0.027758777,
        0.9805506,
        0.21263224,
        0.06546384,
        0.5496738,
        0.28638768,
        0.34101695,
        0.7508749,
    ],
}
b Array { dtype: F32, shape: [3, 3, 1, 1], af_array: 0x560e503c1cb0 }
b Array {
    dtype: F32,
    shape: [3, 3, 1, 1],
    data: [
        0.41050708,
        0.15832818,
        0.3712476,
        0.3543455,
        0.6450288,
        0.9674888,
        0.36364043,
        0.41647816,
        0.5814448,
    ],
}
```
