### PR TITLE
Chore: bump outdated num and rustc versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ afserde = ["serde"]
 
 [dependencies]
 libc = "0.2"
-num  = "0.2"
+num  = "0.4.0"
 lazy_static = "1.0"
 half = "1.5.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -64,7 +64,7 @@ bincode = "1.3"
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
-rustc_version = "0.2"
+rustc_version = "0.3.3"
 
 [[example]]
 name = "helloworld"


### PR DESCRIPTION
I ran "cargo-test" and got 

`test src/algorithm/mod.rs - algorithm::max_ragged (line 1489) ... FAILED`

both before and after the version bump, so there aren't any regressions.

max_ragged seems to be failing because "_af_max_ragged" doesn't show up in the macos lib folder for whatever reason.

My IDE also formatted Cargo.toml,  but I can try and undo that if autoformatting is unwanted.

Fixes #293 