### PR TITLE
Fixed typo in DYLY_LIBRARY_PATH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the rust bindings for ArrayFire from crates.io, the following requirement
 2. Set the evironment variable `AF_PATH` to point to ArrayFire installation root folder.
 3. Make sure to add the path to lib files to your path environment variables.
     - On Linux: do `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$AF_PATH/lib64`
-    - On OSX: do `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$AF_PATH/lib64`
+    - On OSX: do `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$AF_PATH/lib`
     - On Windows: Add `%AF_PATH%\lib` to your PATH environment variable.
 4. Add `arrayfire = "3.8"` to the dependencies section of your project's Cargo.toml file.
    Make sure to change the version to latest available.


### PR DESCRIPTION
Changed `lib64` to `lib`, valid for arrayfire 3.7.2

I think that I have successfully fixed the commit history on my fork so that this will work now. 

Fixes #303