### PR TITLE
Rerun build script when `AF_PATH` changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -305,6 +305,7 @@ fn blob_backends(conf: &Config, build_dir: &std::path::PathBuf) -> (Vec<String>,
                 }
             }
         };
+        println!("cargo:rerun-if-env-changed=AF_PATH");
 
         backend_dirs.push(afpath.join("lib").to_str().to_owned().unwrap().to_string());
         backend_dirs.push(


### PR DESCRIPTION
This would have saved as a lot of debugging after moving the arrayfire folder (it only worked after a `cargo clean`).

See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-env-changed for background info.