### PR TITLE
Error in build script when no backends are found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
     clippy:
         name: Clippy Lints
         runs-on: ubuntu-18.04
+        env:
+            AF_VER: 3.8.0
         steps:
             - name: Checkout Repository
               uses: actions/checkout@master
@@ -83,7 +85,29 @@ jobs:
                   toolchain: stable
                   override: true
                   components: clippy
+
+            - name: Cache ArrayFire
+              uses: actions/cache@v1
+              id: arrayfire
+              with:
+                  path: afbin
+                  key: ${{ runner.os }}-af-${{ env.AF_VER }}
+
+            - name: Download ArrayFire
+              # Only download and cache arrayfire if already not found
+              if: steps.arrayfire.outputs.cache-hit != 'true'
+              run: |
+                  wget --quiet http://arrayfire.s3.amazonaws.com/${AF_VER}/ArrayFire-v${AF_VER}_Linux_x86_64.sh
+                  chmod +x ./ArrayFire-v${AF_VER}_Linux_x86_64.sh
+                  mkdir afbin
+                  ./ArrayFire-v${AF_VER}_Linux_x86_64.sh --skip-license --exclude-subdir --prefix=./afbin
+                  rm ./afbin/lib64/libcu*.so*
+                  rm ./afbin/lib64/libafcuda*.so*
+                  rm ./ArrayFire-v${AF_VER}_Linux_x86_64.sh
+
             - name: Run clippy tool
+              env:
+                AF_PATH: ${{ github.workspace }}/afbin
               uses: actions-rs/cargo@v1
               with:
                   command: clippy

--- a/build.rs
+++ b/build.rs
@@ -449,6 +449,11 @@ fn main() {
     }
 
     let (backends, backend_dirs) = blob_backends(&conf, &build_dir);
+
+    if backends.is_empty() {
+       fail("no arrayfire backends found");
+    }
+
     for backend in backends.iter() {
         println!("cargo:rustc-link-lib=dylib={}", backend);
     }

--- a/build.rs
+++ b/build.rs
@@ -292,13 +292,9 @@ fn blob_backends(conf: &Config, build_dir: &std::path::Path) -> (Vec<String>, Ve
         let afpath = match env::var("AF_PATH") {
             Ok(af_path) => PathBuf::from(&af_path),
             Err(_) => {
-                println!(
-                    "WARNING! USE_LIB is defined,
-                          but AF_PATH is not found,"
-                );
-                println!(
-                    "Trying to find libraries from
-                          known default locations"
+                eprintln!(
+                    "WARNING: USE_LIB is defined, but AF_PATH is not found. Trying to find \
+                    libraries from known default locations."
                 );
                 if cfg!(target_os = "windows") {
                     PathBuf::from("C:\\Program Files\\ArrayFire\\v3\\")

--- a/build.rs
+++ b/build.rs
@@ -71,7 +71,7 @@ fn dir_exists(location: &str) -> bool {
                 eprintln!("WARNING: failed to access `{}`: {}", location, err);
             }
             false
-        },
+        }
     }
 }
 
@@ -83,7 +83,7 @@ fn file_exists(location: &str) -> bool {
                 eprintln!("WARNING: failed to access `{}`: {}", location, err);
             }
             false
-        },
+        }
     }
 }
 
@@ -458,7 +458,7 @@ fn main() {
     let (backends, backend_dirs) = blob_backends(&conf, &build_dir);
 
     if backends.is_empty() {
-       fail("no arrayfire backends found");
+        fail("no arrayfire backends found");
     }
 
     for backend in backends.iter() {

--- a/build.rs
+++ b/build.rs
@@ -66,14 +66,24 @@ fn fail(msg: &str) -> ! {
 fn dir_exists(location: &str) -> bool {
     match fs::metadata(location) {
         Ok(f) => f.is_dir(),
-        Err(_) => false,
+        Err(err) => {
+            if err.kind() != ErrorKind::NotFound {
+                eprintln!("WARNING: failed to access `{}`: {}", location, err);
+            }
+            false
+        },
     }
 }
 
 fn file_exists(location: &str) -> bool {
     match fs::metadata(location) {
         Ok(f) => f.is_file(),
-        Err(_) => false,
+        Err(err) => {
+            if err.kind() != ErrorKind::NotFound {
+                eprintln!("WARNING: failed to access `{}`: {}", location, err);
+            }
+            false
+        },
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -58,8 +58,9 @@ struct Config {
     win_vs_toolset: String,
 }
 
-fn fail(s: &str) -> ! {
-    panic!("\n{}\n\nbuild script failed, must exit now", s)
+fn fail(msg: &str) -> ! {
+    eprintln!("ERROR: {}", msg);
+    std::process::exit(1);
 }
 
 fn dir_exists(location: &str) -> bool {


### PR DESCRIPTION
Fixes #308

Also:

- warn if backend files exist, but are not accessible (e.g. because access is denied).
- improves the formatting of errors and warnings
- print warnings to stderr instead of stdout

Cargo only shows the stderr/stdout of build scripts if they fail. So the new warnings do not clutter the output of successful builds.

Example output when a folder is inaccessible:

```
   Compiling arrayfire v3.8.0 (/workspaces/arrayfire-rust)
error: failed to run custom build command for `arrayfire v3.8.0 (/workspaces/arrayfire-rust)`

Caused by:
  process didn't exit successfully: `/workspaces/arrayfire-rust/target/debug/build/arrayfire-09f04fa2319aeba4/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=AF_PATH

  --- stderr
  WARNING: USE_LIB is defined, but AF_PATH is not found. Trying to find libraries from known default locations.
  WARNING: failed to access `/opt/arrayfire/lib/libafcuda.dll`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libafcuda.dylib`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libafcuda.so`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libafopencl.dll`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libafopencl.dylib`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libafopencl.so`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libaf.dll`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libaf.dylib`: Permission denied (os error 13)
  WARNING: failed to access `/opt/arrayfire/lib/libaf.so`: Permission denied (os error 13)
  ERROR: no arrayfire backends found
```